### PR TITLE
Support string arrays as inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the `onLoad` script to load this package onto the MATLAB path. Run the `onUn
 Dependencies
 ------------
 
-* MATLAB 2010a or later.
+* MATLAB 2017b or later.
 * [matlab-xunit-4.0.0](https://github.com/psexton/matlab-xunit), only if you want to run the unit tests.
 
 License

--- a/src/SemanticVersion.m
+++ b/src/SemanticVersion.m
@@ -211,26 +211,32 @@ classdef SemanticVersion < handle
         end
         
         function set.major(obj, value)
+            value = convertStringsToChars(value);
             obj.major = obj.ensureValidVersionPartValue(value);
         end
         
         function set.minor(obj, value)
+            value = convertStringsToChars(value);
             obj.minor = obj.ensureValidVersionPartValue(value);
         end
         
         function set.patch(obj, value)
+            value = convertStringsToChars(value);
             obj.patch = obj.ensureValidVersionPartValue(value);
         end
         
         function set.prerelease(obj, value)
+            value = convertStringsToChars(value);
             obj.prerelease = obj.ensureValidPrereleaseValue(value);
         end
 
         function set.build_metadata(obj, value)
+            value = convertStringsToChars(value);
             obj.build_metadata = obj.ensureValidBuildMetadataValue(value);
         end
         
         function set.string(obj, value)
+            value = convertStringsToChars(value);
             assert(ischar(value), 'SemanticVersion:invalidValue', ...
                 'Versions should be set using strings');
             

--- a/src/SemanticVersionName.m
+++ b/src/SemanticVersionName.m
@@ -117,14 +117,17 @@ classdef SemanticVersionName < handle
         end
         
         function set.name(obj, value)
+            value = convertStringsToChars(value);
             obj.name = obj.ensureValidNamePartValue(value);
         end
         
         function set.semver(obj, value)
+            value = convertStringsToChars(value);
             obj.semver = obj.ensureValidSemVerPartValue(value);
         end
         
         function set.string(obj, value)
+            value = convertStringsToChars(value);
             assert(ischar(value), 'SemanticVersionName:invalidValue', ...
                 'VersionNames should be set using strings');
             

--- a/tests/MatlabStringTest.m
+++ b/tests/MatlabStringTest.m
@@ -1,0 +1,104 @@
+classdef MatlabStringTest < TestCase
+    %MATLABSTRINGTEST xUnit tests for passing matlab strings into the SemanticVersion and SemanticVersionName classes
+    
+    methods
+        function obj = MatlabStringTest(name)
+            obj = obj@TestCase(name);
+        end
+        
+        function testSemVerCtrCanAcceptString(~)
+            expectedVersion = "1.2.3";
+
+            version = SemanticVersion(expectedVersion);
+            assertEqual(char(expectedVersion), version.string);
+        end
+
+        function testSemVerStringPropCanAcceptString(~)
+            expectedVersion = "1.2.3";
+
+            version = SemanticVersion();
+            version.string = expectedVersion;
+
+            assertEqual(char(expectedVersion), char(version));
+        end
+
+        function testMajorCanAcceptString(~)
+            expectedMajor = "12";
+
+            version = SemanticVersion();
+            version.major = expectedMajor;
+
+            assertEqual(str2num(expectedMajor), version.major);
+        end
+
+        function testMinorCanAcceptString(~)
+            expectedMinor = "44";
+
+            version = SemanticVersion();
+            version.minor = expectedMinor;
+
+            assertEqual(str2num(expectedMinor), version.minor);
+        end
+
+        function testPatchCanAcceptString(~)
+            expectedPatch = "906";
+
+            version = SemanticVersion();
+            version.patch = expectedPatch;
+
+            assertEqual(str2num(expectedPatch), version.patch);
+        end
+        
+        function testPrereleaseCanAcceptString(~)
+            expectedPre = "alpha1";
+
+            version = SemanticVersion();
+            version.prerelease = expectedPre;
+
+            assertEqual(char(expectedPre), version.prerelease);
+        end
+
+        function testBuildMetadataCanAcceptString(~)
+            expectedBuild = "build3d4c2a";
+
+            version = SemanticVersion();
+            version.build_metadata = expectedBuild;
+
+            assertEqual(char(expectedBuild), version.build_metadata);
+        end
+
+        function testSemVerNameCtrCanAcceptString(~)
+            expectedVersionName = "georgia-1.2.3-beta2";
+
+            versionName = SemanticVersionName(expectedVersionName);
+            assertEqual(char(expectedVersionName), versionName.string);
+        end
+
+        function testSemVerNameStringPropCanAcceptString(~)
+            expectedVersionName = "georgia-1.2.3-beta2";
+
+            versionName = SemanticVersionName();
+            versionName.string = expectedVersionName;
+
+            assertEqual(char(expectedVersionName), char(versionName));
+        end
+
+        function testNameCanAcceptString(~)
+            expectedName = "alfred";
+
+            versionName = SemanticVersionName();
+            versionName.name = expectedName;
+
+            assertEqual(char(expectedName), versionName.name);
+        end
+
+        function testVersionCanAcceptString(~)
+            expectedVersion = "45.67.89";
+
+            versionName = SemanticVersionName();
+            versionName.semver = expectedVersion;
+
+            assertEqual(SemanticVersion(expectedVersion), versionName.semver);
+        end
+    end
+end


### PR DESCRIPTION
* Adds support for accepting [string arrays](https://www.mathworks.com/help/matlab/ref/string.html) as inputs. Internal representations and function return values are still char arrays.

* Bumping minimum required MATLAB version from 2010a to 2017b.

Closes #3 